### PR TITLE
Update isCancelable method

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -85,7 +85,7 @@ export default class Cancelable {
    */
 
   static isCancelable(value) {
-    return value instanceof Cancelable && value[CANCELABLE_IDENTIFIER];
+    return !!(value && value[CANCELABLE_IDENTIFIER]);
   }
 
   /**


### PR DESCRIPTION
The Cancelable.isCancelable method was updated to simplify the check. Previously it used `instanceof` operator to check is a given value was a Cancelable but it was redundant and it had unexpected behaviours using the browser distribution.