### PR TITLE
Add CancelationError to the exported modules

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@
 
 const CANCELABLE_IDENTIFIER = '@@Cancelable';
 
-class CancelationError extends Error {
+export class CancelationError extends Error {
   constructor() {
     super('Cancelable was canceled');
 


### PR DESCRIPTION
This adds `CancelationError` to the exported modules in order to be consumed by external APIs.